### PR TITLE
Add redis caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ $ npm install
 The server is configured by setting environment variables. These settings include:
 
 - `PORT` - The Port number to use for the server. Defaults to `8888`.
+- `REDIS_URL`, `REDISCLOUD_URL`, or `REDISTOGO_URL` - The URL of the Redis server used for caching. Defaults to none.
+- `CACHE_EXPIRE` - The number of seconds to cache responses. Defaults to `3600` seconds.
 
 ## How to use
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "express": "~3.0.4",
     "request": "~2.14.0"
   },
+  "optionalDependencies": {
+    "hiredis": "~0.1.14",
+    "redis": "~0.8.2"
+  },
   "license": "http://www.apache.org/licenses/LICENSE-2.0.html",
   "engines": {
     "node": "0.8.x",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,51 @@ var express = require( 'express' ),
     request = require( 'request' ),
     app = express(),
     port = process.env.PORT || 8888,
-    server;
+    cacheExpire = process.env.CACHE_EXPIRE || 60 * 60, // one hour
+    server,
+    redis;
+
+var redisURL = process.env.REDIS_URL ||
+               process.env.REDISCLOUD_URL ||
+               process.env.REDISTOGO_URL;
+
+if ( redisURL ) {
+  console.log( "Using Redis cache with " + redisURL );
+
+  try {
+    redisURL = require( "url" ).parse( redisURL );
+    redis = require( "redis" ).createClient( redisURL.port, redisURL.hostname );
+
+    if ( redisURL.auth ) {
+      redis.auth ( redisURL.auth.split( ":" )[ 1 ] );
+    }
+  } catch (ex) {
+    console.warning( "Failed to load Redis:" + ex );
+  }
+}
+
+/**
+ * Redis caching middleware
+ */
+function cacheCheck( req, res, next ) {
+  var url = req.params ? req.params[ 0 ] : null;
+
+  if ( !url ) {
+    return process.nextTick(function() {
+      next();
+    });
+  }
+
+  redis.mget( [ url + ":href", url + ":contentType" ], function( err, response ) {
+    if ( response[ 0 ] && response[ 1 ] ) {
+      res.json({ href: response[ 0 ], contentType: response[ 1 ] });
+    } else {
+      process.nextTick(function() {
+        next();
+      });
+    }
+  });
+}
 
 /**
  * Discover the mime type for a given resource, following redirects
@@ -24,8 +68,15 @@ function getContentType( url, callback ) {
   });
 }
 
-app.get( '/api/url/*', function( req, res ) {
+var middleware = [];
+
+if ( redis ) {
+  middleware.push( cacheCheck );
+}
+
+app.get( '/api/url/*', middleware, function( req, res ) {
   var url = req.params[ 0 ];
+
   if ( !url ) {
     res.json( { error: "Expected url param, found none." }, 500 );
     return;
@@ -38,6 +89,12 @@ app.get( '/api/url/*', function( req, res ) {
     }
 
     res.json( result );
+    if ( redis ) {
+      redis.multi()
+        .setex(url + ":href", cacheExpire, result.href)
+        .setex(url + ":contentType", cacheExpire, result.contentType)
+        .exec();
+    }
   });
 });
 


### PR DESCRIPTION
wheeee!

Builds on top of the heroku patch. Adding caching support to a WebDNA instance running on Heroku is as simple as running one of two commands:
- `heroku addons:add redistogo:nano`
- `heroku addons:add rediscloud:20`

Then everything is super fast!
