### PR TITLE
Fix Bug 951195 - node-hubble can make requests to anywhere

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,9 @@ module.exports = function( grunt ) {
   grunt.initConfig({
     pkg: grunt.file.readJSON( "package.json" ),
     jshint: {
+      options: {
+        sub: true
+      },
       files: [
         "Gruntfile.js",
         "server.js",


### PR DESCRIPTION
This adds a Hosts Blacklist (defaults to localhost and 127.0.0.1) and a Ports Whitelist (defaults to 80, 8080, 443).  Users can provide their own list if they want to override. 

NOTE: there are 3 failing `/img/` route tests that I've fixed in the cache-read-timeout patch, so you can ignore them.
